### PR TITLE
Upgrade rdpwrapper to 1.6.2

### DIFF
--- a/rdpwrapper/rdpwrapper.nuspec
+++ b/rdpwrapper/rdpwrapper.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>rdpwrapper</id>
     <title>RDP Wrapper</title>
-    <version>1.6.0.2</version>
+    <version>1.6.2</version>
     <authors>Stas'M</authors>
     <owners>Leon Volovyk</owners>
     <summary>RDP Wrapper Library</summary>

--- a/rdpwrapper/tools/chocolateyinstall.ps1
+++ b/rdpwrapper/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@
 
 $packageName= 'rdpwrapper'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://github.com/stascorp/rdpwrap/releases/download/v1.6/RDPWrap-v1.6.zip' # download url
+$url        = 'https://github.com/stascorp/rdpwrap/releases/download/v1.6.2/RDPWrap-v1.6.2.zip' # download url
 
 Install-ChocolateyZipPackage $packageName $url $toolsDir
 

--- a/rdpwrapper/tools/chocolateyuninstall.ps1
+++ b/rdpwrapper/tools/chocolateyuninstall.ps1
@@ -3,4 +3,4 @@
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 Start-ChocolateyProcessAsAdmin '-u' (Join-Path $toolsDir 'RDPWInst.exe')
 
-Uninstall-ChocolateyZipPackage $packageName 'RDPWrap-v1.6.zip'
+Uninstall-ChocolateyZipPackage $packageName 'RDPWrap-v1.6.2.zip'


### PR DESCRIPTION
This version includes a fix for Windows 10 Creators 1709.