### PR TITLE
RDP Wrapper improvements

### DIFF
--- a/rdpwrapper/rdpwrapper.nuspec
+++ b/rdpwrapper/rdpwrapper.nuspec
@@ -12,6 +12,10 @@
     RDP Wrapper works as a layer between Service Control Manager and Terminal Services, so the original termsrv.dll file remains untouched. Also this method is very strong against Windows Update.
 
     This package uses tmaguire's fork of RDP Wrapper, because the original author, Stas'M hasn't updated the software since 2018.
+
+    ## Package Parameters
+
+    - `/NoUpdateService` - Disables rdpwrap.ini updates on system startup
     </description>
     <projectUrl>https://github.com/tmaguire/rdpwrap</projectUrl>
     <packageSourceUrl>https://github.com/Leon99/ChocolateyPackages/tree/master/rdpwrapper</packageSourceUrl>

--- a/rdpwrapper/rdpwrapper.nuspec
+++ b/rdpwrapper/rdpwrapper.nuspec
@@ -4,17 +4,19 @@
   <metadata>
     <id>rdpwrapper</id>
     <title>RDP Wrapper</title>
-    <version>1.6.2</version>
-    <authors>Stas'M</authors>
+    <version>1.6.3</version>
+    <authors>Stas'M, Tom Maguire</authors>
     <owners>Leon Volovyk</owners>
     <summary>RDP Wrapper Library</summary>
     <description>The goal of this project is to enable Remote Desktop Host support and concurrent RDP sessions on reduced functionality systems for home usage.
     RDP Wrapper works as a layer between Service Control Manager and Terminal Services, so the original termsrv.dll file remains untouched. Also this method is very strong against Windows Update.
+
+    This package uses tmaguire's fork of RDP Wrapper, because the original author, Stas'M hasn't updated the software since 2018.
     </description>
-    <projectUrl>https://github.com/stascorp/rdpwrap</projectUrl>
+    <projectUrl>https://github.com/tmaguire/rdpwrap</projectUrl>
     <packageSourceUrl>https://github.com/Leon99/ChocolateyPackages/tree/master/rdpwrapper</packageSourceUrl>
     <copyright>Stas'M</copyright>
-    <licenseUrl>https://raw.githubusercontent.com/stascorp/rdpwrap/master/LICENSE</licenseUrl>
+    <licenseUrl>https://raw.githubusercontent.com/tmaguire/rdpwrap/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>admin rdp remote desktop</tags>
   </metadata>

--- a/rdpwrapper/tools/chocolateyinstall.ps1
+++ b/rdpwrapper/tools/chocolateyinstall.ps1
@@ -7,5 +7,4 @@ $checkSum   = '8d3c945ee817f0c8d8d1ee4de92db6e12b75bf165ef01a847459b5b5f8d7b0d3'
 
 Install-ChocolateyZipPackage $packageName $url $toolsDir -ChecksumType "sha256" -Checksum $checkSum
 
-Start-ChocolateyProcessAsAdmin '-i' (Join-Path $toolsDir 'RDPWInst.exe') -validExitCodes @(0,1)
-Start-ChocolateyProcessAsAdmin '-w' (Join-Path $toolsDir 'RDPWInst.exe')
+Start-ChocolateyProcessAsAdmin '-i -o' (Join-Path $toolsDir 'RDPWInst.exe') -validExitCodes @(0,1)

--- a/rdpwrapper/tools/chocolateyinstall.ps1
+++ b/rdpwrapper/tools/chocolateyinstall.ps1
@@ -4,7 +4,16 @@ $packageName= 'rdpwrapper'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $url        = 'https://github.com/tmaguire/rdpwrap/releases/download/v1.6.3/RDPWrapper-1.6.3.zip'
 $checkSum   = '8d3c945ee817f0c8d8d1ee4de92db6e12b75bf165ef01a847459b5b5f8d7b0d3'
+$PackageParameters = Get-PackageParameters
 
 Install-ChocolateyZipPackage $packageName $url $toolsDir -ChecksumType "sha256" -Checksum $checkSum
 
 Start-ChocolateyProcessAsAdmin '-i -o' (Join-Path $toolsDir 'RDPWInst.exe') -validExitCodes @(0,1)
+
+# Create 'rdpwrap.ini' auto update task
+if (-not ($PackageParameters.NoUpdateService)) {
+    Write-Host "Schedule auto update of 'rdpwrap.ini' on startup."
+    schtasks /create /f /sc ONSTART /tn "RDP Wrapper Autoupdate" /tr "$toolsDir\RDPWInst.exe -w" /ru SYSTEM /delay 0000:10
+    $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries
+    Set-ScheduledTask -TaskName 'RDP Wrapper Autoupdate' -Settings $settings
+}

--- a/rdpwrapper/tools/chocolateyinstall.ps1
+++ b/rdpwrapper/tools/chocolateyinstall.ps1
@@ -2,8 +2,8 @@
 
 $packageName= 'rdpwrapper'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://github.com/stascorp/rdpwrap/releases/download/v1.6.2/RDPWrap-v1.6.2.zip' # download url
-$checkSum   = '35A9481DDBED5177431A9EA4BD09468FE987797D7B1231D64942D17EB54EC269'
+$url        = 'https://github.com/tmaguire/rdpwrap/releases/download/v1.6.3/RDPWrapper-1.6.3.zip'
+$checkSum   = '8d3c945ee817f0c8d8d1ee4de92db6e12b75bf165ef01a847459b5b5f8d7b0d3'
 
 Install-ChocolateyZipPackage $packageName $url $toolsDir -ChecksumType "sha256" -Checksum $checkSum
 

--- a/rdpwrapper/tools/chocolateyuninstall.ps1
+++ b/rdpwrapper/tools/chocolateyuninstall.ps1
@@ -3,4 +3,4 @@
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 Start-ChocolateyProcessAsAdmin '-u' (Join-Path $toolsDir 'RDPWInst.exe')
 
-Uninstall-ChocolateyZipPackage $packageName 'RDPWrap-v1.6.2.zip'
+Uninstall-ChocolateyZipPackage $packageName 'RDPWrap-v1.6.3.zip'

--- a/rdpwrapper/tools/chocolateyuninstall.ps1
+++ b/rdpwrapper/tools/chocolateyuninstall.ps1
@@ -4,3 +4,6 @@ $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 Start-ChocolateyProcessAsAdmin '-u' (Join-Path $toolsDir 'RDPWInst.exe')
 
 Uninstall-ChocolateyZipPackage $packageName 'RDPWrap-v1.6.3.zip'
+
+# Remove 'rdpwrap.ini' auto update task
+schtasks /delete /f /tn "RDP Wrapper Autoupdate"


### PR DESCRIPTION
Hi, I want to suggest a few improvements to the RDP Wrapper package. Let me know what you think.

## Change repo

https://github.com/Leon99/ChocolateyPackages/commit/63d437e20c9ebae882edbcbcc27b8f1a2228de23 Since the original repo of RDP Wrapper is abandoned, I think that it would be reasonable to switch to a reliable fork. I think that tmaguire's [fork](https://github.com/tmaguire/rdpwrap) is pretty well maintained, with regular commits. It supports the latest version of Windows 11 out of the box.

I know that forks are "unofficial" and everything, but I think that having a so called "unofficial"  version is still better than using an abandonware. Although if you disagree with me, I can completely understand that. It's your choco package after all.

## Fix installer
https://github.com/Leon99/ChocolateyPackages/commit/c1008bba5466d87923c50300bf1c1e91c9ec6928 When you try to install RDP Wrapper using [v1.6.2](https://community.chocolatey.org/packages/rdpwrapper/1.6.2) of the package (latest) from choco on modern Windows (I tested it with 10 update 20H2), you get the following error:
```
rdpwrapper v1.6.2 [Approved]
rdpwrapper package files install completed. Performing other installation steps.
Downloading rdpwrapper
  from 'https://github.com/stascorp/rdpwrap/releases/download/v1.6.2/RDPWrap-v1.6.2.zip'
Progress: 100% - Completed download of C:\Users\User\AppData\Local\Temp\chocolatey\rdpwrapper\1.6.2\RDPWrap-v1.6.2.zip (1.52 MB).
Download of RDPWrap-v1.6.2.zip (1.52 MB) completed.
Hashes match.
Extracting C:\Users\User\AppData\Local\Temp\chocolatey\rdpwrapper\1.6.2\RDPWrap-v1.6.2.zip to C:\ProgramData\chocolatey\lib\rdpwrapper\tools...
C:\ProgramData\chocolatey\lib\rdpwrapper\tools
0
WARNING: User (you) cancelled the installation.
ERROR: Running ["C:\ProgramData\chocolatey\lib\rdpwrapper\tools\RDPWInst.exe" -w] was not successful. Exit code was '5'. Exit code indicates the following: User (you) cancelled the installation..
The install of rdpwrapper was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\rdpwrapper\tools\chocolateyinstall.ps1'.
 See log for details.

Chocolatey installed 0/1 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Failures
 - rdpwrapper (exited 5) - Error while running 'C:\ProgramData\chocolatey\lib\rdpwrapper\tools\chocolateyinstall.ps1'.
 See log for details.
```

caused by
https://github.com/Leon99/ChocolateyPackages/blob/776d7f939f5a14d839c59626061d33081c78aee5/rdpwrapper/tools/chocolateyinstall.ps1#L11

I fixed the installer by using the `-i -o` parameters while installing. `-o` does the same thing as `-w` but the former one can be used **while** installing the program.

## Auto update `rdpwrap.ini`

https://github.com/Leon99/ChocolateyPackages/commit/56a7b244dadc15d7831a76dd539c2a3472f5e6c0 RDP Wrap uses ini files to determine how it should operate on your version of Windows. Since Windows updates are released quite often, the ini files can be updated without having to re-release RDP Wrap. You can use `RDPWInst -w` to update `rdpwrap.ini` to the latest version (available in the original repo of RDP Wrapper, or in tmaguire's, if you use his fork). I have set up a task (based on [asmtron's update script](https://github.com/asmtron/rdpwrap/raw/master/autoupdate.zip)) that automatically runs `RDPWInst -w` every time Windows boots.